### PR TITLE
feat: GPT-5.2モデルをOpenAIとAzure OpenAIに追加

### DIFF
--- a/app/public/index.html
+++ b/app/public/index.html
@@ -248,6 +248,14 @@
                             <input type="text" id="azureEndpointGpt5" placeholder="https://your-resource.openai.azure.com/openai/deployments/your-deployment/chat/completions?api-version=2023-05-15">
                         </div>
                         <div class="form-group">
+                            <label for="azureEndpointGpt52Mini">gpt-5.2-mini エンドポイントURL:</label>
+                            <input type="text" id="azureEndpointGpt52Mini" placeholder="https://your-resource.openai.azure.com/openai/deployments/your-deployment/chat/completions?api-version=2023-05-15">
+                        </div>
+                        <div class="form-group">
+                            <label for="azureEndpointGpt52">gpt-5.2 エンドポイントURL:</label>
+                            <input type="text" id="azureEndpointGpt52" placeholder="https://your-resource.openai.azure.com/openai/deployments/your-deployment/chat/completions?api-version=2023-05-15">
+                        </div>
+                        <div class="form-group">
                             <label for="azureEndpointO1Mini">o1-mini エンドポイントURL:</label>
                             <input type="text" id="azureEndpointO1Mini" placeholder="https://your-resource.openai.azure.com/openai/deployments/your-deployment/chat/completions?api-version=2023-05-15">
                         </div>

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -251,14 +251,6 @@
                             <label for="azureEndpointGpt52">gpt-5.2 エンドポイントURL:</label>
                             <input type="text" id="azureEndpointGpt52" placeholder="https://your-resource.openai.azure.com/openai/deployments/your-deployment/chat/completions?api-version=2023-05-15">
                         </div>
-                        <div class="form-group">
-                            <label for="azureEndpointO1Mini">o1-mini エンドポイントURL:</label>
-                            <input type="text" id="azureEndpointO1Mini" placeholder="https://your-resource.openai.azure.com/openai/deployments/your-deployment/chat/completions?api-version=2023-05-15">
-                        </div>
-                        <div class="form-group">
-                            <label for="azureEndpointO1">o1 エンドポイントURL:</label>
-                            <input type="text" id="azureEndpointO1" placeholder="https://your-resource.openai.azure.com/openai/deployments/your-deployment/chat/completions?api-version=2023-05-15">
-                        </div>
                         <div class="form-group" style="margin-top: 16px; padding-top: 16px; border-top: 1px solid var(--border-color);">
                             <label for="azureEndpointEmbedding">text-embedding-3-large エンドポイントURL（RAG用）:</label>
                             <input type="text" id="azureEndpointEmbedding" placeholder="https://your-resource.openai.azure.com/openai/deployments/text-embedding-3-large/embeddings?api-version=2023-05-15">

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -248,10 +248,6 @@
                             <input type="text" id="azureEndpointGpt5" placeholder="https://your-resource.openai.azure.com/openai/deployments/your-deployment/chat/completions?api-version=2023-05-15">
                         </div>
                         <div class="form-group">
-                            <label for="azureEndpointGpt52Mini">gpt-5.2-mini エンドポイントURL:</label>
-                            <input type="text" id="azureEndpointGpt52Mini" placeholder="https://your-resource.openai.azure.com/openai/deployments/your-deployment/chat/completions?api-version=2023-05-15">
-                        </div>
-                        <div class="form-group">
                             <label for="azureEndpointGpt52">gpt-5.2 エンドポイントURL:</label>
                             <input type="text" id="azureEndpointGpt52" placeholder="https://your-resource.openai.azure.com/openai/deployments/your-deployment/chat/completions?api-version=2023-05-15">
                         </div>

--- a/app/public/js/core/config.js
+++ b/app/public/js/core/config.js
@@ -269,7 +269,7 @@ window.CONFIG = {
      */
     MODELS: {
         // サポートされているモデル
-        OPENAI: ['gpt-4o-mini', 'gpt-4o', 'gpt-5-mini', 'gpt-5', 'gpt-5.2', 'o1-mini', 'o1'],
+        OPENAI: ['gpt-4o-mini', 'gpt-4o', 'gpt-5-mini', 'gpt-5', 'gpt-5.2'],
         GEMINI: ['gemini-3-pro-preview', 'gemini-2.5-pro', 'gemini-2.5-flash'],
         CLAUDE: [
             'claude-opus-4-5',
@@ -288,8 +288,6 @@ window.CONFIG = {
             'gpt-5-mini': 'GPT-5 Mini',
             'gpt-5': 'GPT-5',
             'gpt-5.2': 'GPT-5.2',
-            'o1-mini': 'o1 Mini',
-            'o1': 'o1',
 
             // Gemini
             'gemini-3-pro-preview': 'Gemini 3 Pro Preview',

--- a/app/public/js/core/config.js
+++ b/app/public/js/core/config.js
@@ -269,7 +269,7 @@ window.CONFIG = {
      */
     MODELS: {
         // サポートされているモデル
-        OPENAI: ['gpt-4o-mini', 'gpt-4o', 'gpt-5-mini', 'gpt-5', 'gpt-5.2-mini', 'gpt-5.2', 'o1-mini', 'o1'],
+        OPENAI: ['gpt-4o-mini', 'gpt-4o', 'gpt-5-mini', 'gpt-5', 'gpt-5.2', 'o1-mini', 'o1'],
         GEMINI: ['gemini-3-pro-preview', 'gemini-2.5-pro', 'gemini-2.5-flash'],
         CLAUDE: [
             'claude-opus-4-5',
@@ -278,7 +278,7 @@ window.CONFIG = {
         ],
         
         // OpenAI Responses APIでのWeb検索をサポートするモデル
-        OPENAI_WEB_SEARCH_COMPATIBLE: ['gpt-5-mini', 'gpt-5', 'gpt-5.2-mini', 'gpt-5.2'],
+        OPENAI_WEB_SEARCH_COMPATIBLE: ['gpt-5-mini', 'gpt-5', 'gpt-5.2'],
         
         // モデルの表示名マッピング
         DISPLAY_NAMES: {
@@ -287,7 +287,6 @@ window.CONFIG = {
             'gpt-4o': 'GPT-4o',
             'gpt-5-mini': 'GPT-5 Mini',
             'gpt-5': 'GPT-5',
-            'gpt-5.2-mini': 'GPT-5.2 Mini',
             'gpt-5.2': 'GPT-5.2',
             'o1-mini': 'o1 Mini',
             'o1': 'o1',

--- a/app/public/js/core/config.js
+++ b/app/public/js/core/config.js
@@ -269,7 +269,7 @@ window.CONFIG = {
      */
     MODELS: {
         // サポートされているモデル
-        OPENAI: ['gpt-4o-mini', 'gpt-4o', 'gpt-5-mini', 'gpt-5', 'o1-mini', 'o1'],
+        OPENAI: ['gpt-4o-mini', 'gpt-4o', 'gpt-5-mini', 'gpt-5', 'gpt-5.2-mini', 'gpt-5.2', 'o1-mini', 'o1'],
         GEMINI: ['gemini-3-pro-preview', 'gemini-2.5-pro', 'gemini-2.5-flash'],
         CLAUDE: [
             'claude-opus-4-5',
@@ -278,7 +278,7 @@ window.CONFIG = {
         ],
         
         // OpenAI Responses APIでのWeb検索をサポートするモデル
-        OPENAI_WEB_SEARCH_COMPATIBLE: ['gpt-5-mini', 'gpt-5'],
+        OPENAI_WEB_SEARCH_COMPATIBLE: ['gpt-5-mini', 'gpt-5', 'gpt-5.2-mini', 'gpt-5.2'],
         
         // モデルの表示名マッピング
         DISPLAY_NAMES: {
@@ -287,6 +287,8 @@ window.CONFIG = {
             'gpt-4o': 'GPT-4o',
             'gpt-5-mini': 'GPT-5 Mini',
             'gpt-5': 'GPT-5',
+            'gpt-5.2-mini': 'GPT-5.2 Mini',
+            'gpt-5.2': 'GPT-5.2',
             'o1-mini': 'o1 Mini',
             'o1': 'o1',
 

--- a/app/public/js/core/domElements.js
+++ b/app/public/js/core/domElements.js
@@ -48,8 +48,7 @@ window.Elements = (function() {
         'apiKeyModal', 'saveApiKey', 'cancelApiKey', 
         'openaiSystemRadio', 'geminiSystemRadio', 'claudeSystemRadio', 'openaiRadio', 'azureRadio',
         'apiKeyInput', 'azureApiKeyInput', 'geminiApiKeyInput', 'claudeApiKeyInput', 'azureEndpointGpt4oMini', 
-        'azureEndpointGpt4o', 'azureEndpointGpt5Mini', 'azureEndpointGpt5',
-        'azureEndpointGpt52', 'azureEndpointO1Mini', 'azureEndpointO1', 
+        'azureEndpointGpt4o', 'azureEndpointGpt5Mini', 'azureEndpointGpt5', 'azureEndpointGpt52', 
         'openaiSystemSettings', 'geminiSystemSettings', 'claudeSystemSettings', 'openaiSettings', 'azureSettings',
         
         // チャット名前変更関連

--- a/app/public/js/core/domElements.js
+++ b/app/public/js/core/domElements.js
@@ -49,8 +49,7 @@ window.Elements = (function() {
         'openaiSystemRadio', 'geminiSystemRadio', 'claudeSystemRadio', 'openaiRadio', 'azureRadio',
         'apiKeyInput', 'azureApiKeyInput', 'geminiApiKeyInput', 'claudeApiKeyInput', 'azureEndpointGpt4oMini', 
         'azureEndpointGpt4o', 'azureEndpointGpt5Mini', 'azureEndpointGpt5',
-        'azureEndpointGpt52Mini', 'azureEndpointGpt52',
-        'azureEndpointO1Mini', 'azureEndpointO1', 
+        'azureEndpointGpt52', 'azureEndpointO1Mini', 'azureEndpointO1', 
         'openaiSystemSettings', 'geminiSystemSettings', 'claudeSystemSettings', 'openaiSettings', 'azureSettings',
         
         // チャット名前変更関連

--- a/app/public/js/core/domElements.js
+++ b/app/public/js/core/domElements.js
@@ -49,6 +49,7 @@ window.Elements = (function() {
         'openaiSystemRadio', 'geminiSystemRadio', 'claudeSystemRadio', 'openaiRadio', 'azureRadio',
         'apiKeyInput', 'azureApiKeyInput', 'geminiApiKeyInput', 'claudeApiKeyInput', 'azureEndpointGpt4oMini', 
         'azureEndpointGpt4o', 'azureEndpointGpt5Mini', 'azureEndpointGpt5',
+        'azureEndpointGpt52Mini', 'azureEndpointGpt52',
         'azureEndpointO1Mini', 'azureEndpointO1', 
         'openaiSystemSettings', 'geminiSystemSettings', 'claudeSystemSettings', 'openaiSettings', 'azureSettings',
         

--- a/app/public/js/modals/apiSettings/apiSettingsModal.js
+++ b/app/public/js/modals/apiSettings/apiSettingsModal.js
@@ -52,9 +52,7 @@ class ApiSettingsModal {
             azureEndpointGpt4o: UICache.getInstance.get('azureEndpointGpt4o'),
             azureEndpointGpt5Mini: UICache.getInstance.get('azureEndpointGpt5Mini'),
             azureEndpointGpt5: UICache.getInstance.get('azureEndpointGpt5'),
-            azureEndpointGpt52: UICache.getInstance.get('azureEndpointGpt52'),
-            azureEndpointO1Mini: UICache.getInstance.get('azureEndpointO1Mini'),
-            azureEndpointO1: UICache.getInstance.get('azureEndpointO1')
+            azureEndpointGpt52: UICache.getInstance.get('azureEndpointGpt52')
         };
         
         // すべてのAPIキーを設定（保持）
@@ -102,8 +100,6 @@ class ApiSettingsModal {
                     elements.azureEndpointGpt5Mini.value = apiSettings.azureEndpoints['gpt-5-mini'] || '';
                     elements.azureEndpointGpt5.value = apiSettings.azureEndpoints['gpt-5'] || '';
                     elements.azureEndpointGpt52.value = apiSettings.azureEndpoints['gpt-5.2'] || '';
-                    elements.azureEndpointO1Mini.value = apiSettings.azureEndpoints['o1-mini'] || '';
-                    elements.azureEndpointO1.value = apiSettings.azureEndpoints['o1'] || '';
                 }
 
                 // Azure埋め込みエンドポイント設定を適用（RAG用）

--- a/app/public/js/modals/apiSettings/apiSettingsModal.js
+++ b/app/public/js/modals/apiSettings/apiSettingsModal.js
@@ -52,6 +52,8 @@ class ApiSettingsModal {
             azureEndpointGpt4o: UICache.getInstance.get('azureEndpointGpt4o'),
             azureEndpointGpt5Mini: UICache.getInstance.get('azureEndpointGpt5Mini'),
             azureEndpointGpt5: UICache.getInstance.get('azureEndpointGpt5'),
+            azureEndpointGpt52Mini: UICache.getInstance.get('azureEndpointGpt52Mini'),
+            azureEndpointGpt52: UICache.getInstance.get('azureEndpointGpt52'),
             azureEndpointO1Mini: UICache.getInstance.get('azureEndpointO1Mini'),
             azureEndpointO1: UICache.getInstance.get('azureEndpointO1')
         };
@@ -100,6 +102,8 @@ class ApiSettingsModal {
                     elements.azureEndpointGpt4o.value = apiSettings.azureEndpoints['gpt-4o'] || '';
                     elements.azureEndpointGpt5Mini.value = apiSettings.azureEndpoints['gpt-5-mini'] || '';
                     elements.azureEndpointGpt5.value = apiSettings.azureEndpoints['gpt-5'] || '';
+                    elements.azureEndpointGpt52Mini.value = apiSettings.azureEndpoints['gpt-5.2-mini'] || '';
+                    elements.azureEndpointGpt52.value = apiSettings.azureEndpoints['gpt-5.2'] || '';
                     elements.azureEndpointO1Mini.value = apiSettings.azureEndpoints['o1-mini'] || '';
                     elements.azureEndpointO1.value = apiSettings.azureEndpoints['o1'] || '';
                 }

--- a/app/public/js/modals/apiSettings/apiSettingsModal.js
+++ b/app/public/js/modals/apiSettings/apiSettingsModal.js
@@ -52,7 +52,6 @@ class ApiSettingsModal {
             azureEndpointGpt4o: UICache.getInstance.get('azureEndpointGpt4o'),
             azureEndpointGpt5Mini: UICache.getInstance.get('azureEndpointGpt5Mini'),
             azureEndpointGpt5: UICache.getInstance.get('azureEndpointGpt5'),
-            azureEndpointGpt52Mini: UICache.getInstance.get('azureEndpointGpt52Mini'),
             azureEndpointGpt52: UICache.getInstance.get('azureEndpointGpt52'),
             azureEndpointO1Mini: UICache.getInstance.get('azureEndpointO1Mini'),
             azureEndpointO1: UICache.getInstance.get('azureEndpointO1')
@@ -102,7 +101,6 @@ class ApiSettingsModal {
                     elements.azureEndpointGpt4o.value = apiSettings.azureEndpoints['gpt-4o'] || '';
                     elements.azureEndpointGpt5Mini.value = apiSettings.azureEndpoints['gpt-5-mini'] || '';
                     elements.azureEndpointGpt5.value = apiSettings.azureEndpoints['gpt-5'] || '';
-                    elements.azureEndpointGpt52Mini.value = apiSettings.azureEndpoints['gpt-5.2-mini'] || '';
                     elements.azureEndpointGpt52.value = apiSettings.azureEndpoints['gpt-5.2'] || '';
                     elements.azureEndpointO1Mini.value = apiSettings.azureEndpoints['o1-mini'] || '';
                     elements.azureEndpointO1.value = apiSettings.azureEndpoints['o1'] || '';

--- a/app/public/js/modals/modalHandlers.js
+++ b/app/public/js/modals/modalHandlers.js
@@ -72,7 +72,6 @@ class ModalHandlers {
                     'gpt-4o': 'azureEndpointGpt4o',
                     'gpt-5-mini': 'azureEndpointGpt5Mini',
                     'gpt-5': 'azureEndpointGpt5',
-                    'gpt-5.2-mini': 'azureEndpointGpt52Mini',
                     'gpt-5.2': 'azureEndpointGpt52',
                     'o1-mini': 'azureEndpointO1Mini',
                     'o1': 'azureEndpointO1'

--- a/app/public/js/modals/modalHandlers.js
+++ b/app/public/js/modals/modalHandlers.js
@@ -72,6 +72,8 @@ class ModalHandlers {
                     'gpt-4o': 'azureEndpointGpt4o',
                     'gpt-5-mini': 'azureEndpointGpt5Mini',
                     'gpt-5': 'azureEndpointGpt5',
+                    'gpt-5.2-mini': 'azureEndpointGpt52Mini',
+                    'gpt-5.2': 'azureEndpointGpt52',
                     'o1-mini': 'azureEndpointO1Mini',
                     'o1': 'azureEndpointO1'
                 };

--- a/app/public/js/modals/modalHandlers.js
+++ b/app/public/js/modals/modalHandlers.js
@@ -72,9 +72,7 @@ class ModalHandlers {
                     'gpt-4o': 'azureEndpointGpt4o',
                     'gpt-5-mini': 'azureEndpointGpt5Mini',
                     'gpt-5': 'azureEndpointGpt5',
-                    'gpt-5.2': 'azureEndpointGpt52',
-                    'o1-mini': 'azureEndpointO1Mini',
-                    'o1': 'azureEndpointO1'
+                    'gpt-5.2': 'azureEndpointGpt52'
                 };
 
                 // 各エンドポイントを保存（window.ElementsまたはUICacheから取得）


### PR DESCRIPTION
- config.js: gpt-5.2-miniとgpt-5.2をモデルリスト・Web検索対応リスト・表示名に追加
- index.html: Azure用のGPT-5.2エンドポイント入力フィールドを追加
- domElements.js: GPT-5.2用DOM要素参照を追加
- apiSettingsModal.js: GPT-5.2エンドポイントの取得・設定処理を追加
- modalHandlers.js: GPT-5.2エンドポイントの保存処理を追加